### PR TITLE
Fix import path in tests

### DIFF
--- a/tests/test_calculator_plugin.py
+++ b/tests/test_calculator_plugin.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sss.plugin_example import CalculatorPlugin
+from plugin_example import CalculatorPlugin
 
 class TestCalculatorPlugin(unittest.TestCase):
     def test_addition(self):

--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sss.zero_system import ZeroSystem
+from zero_system import ZeroSystem
 
 
 class TestDynamicSkill(unittest.TestCase):

--- a/tests/test_interaction_logging.py
+++ b/tests/test_interaction_logging.py
@@ -1,7 +1,7 @@
 import os
 import json
 import unittest
-import sss.zero_system as zs
+import zero_system as zs
 
 class TestInteractionLogging(unittest.TestCase):
     def test_interact_creates_log_file(self):

--- a/tests/test_mindful_embodiment.py
+++ b/tests/test_mindful_embodiment.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sss.zero_system import MindfulEmbodimentSkill
+from zero_system import MindfulEmbodimentSkill
 
 
 class TestMindfulEmbodiment(unittest.TestCase):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,6 +1,6 @@
 import logging
 import pytest
-from sss.zero_system import is_sibling_request, ZeroSystem
+from zero_system import is_sibling_request, ZeroSystem
 
 
 def test_is_sibling_request_true():

--- a/tests/test_zero_system.py
+++ b/tests/test_zero_system.py
@@ -1,6 +1,6 @@
 import unittest
 
-from sss.zero_system import ZeroSystem
+from zero_system import ZeroSystem
 
 class TestZeroSystem(unittest.TestCase):
     def test_create_sibling_increments_count(self):


### PR DESCRIPTION
## Summary
- fix imports across test suite to use project modules directly

## Testing
- `python -m unittest discover -v`

------
https://chatgpt.com/codex/tasks/task_e_684854a450348330b745892b403f2f5f