### PR TITLE
Fix import and restore clean tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))

--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -2,18 +2,6 @@ import unittest
 
 from sss.zero_system import ZeroSystem
 
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-  =======
-
-  class TestDynamicSkill(unittest.TestCase):
-      def test_dynamic_skill_registration(self):
-          system = ZeroSystem()
-          message = system.brother_ai.grow("test_skill")
-          self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-          self.assertIn("test_skill", system.brother_ai.skills)
-          self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-          self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-  >>>>>>> main
 
 class TestDynamicSkill(unittest.TestCase):
     def test_dynamic_skill_registration(self):
@@ -22,11 +10,8 @@ class TestDynamicSkill(unittest.TestCase):
         self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
         self.assertIn("test_skill", system.brother_ai.skills)
         self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-        self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
+        self.assertEqual(
+            system.brother_ai.skills["test_skill"](),
+            {"status": "under_development"}
+        )
 
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-
-  if __name__ == "__main__":
-      unittest.main()
-  =======
-  >>>>>>> main

--- a/tests/test_mindful_embodiment.py
+++ b/tests/test_mindful_embodiment.py
@@ -3,11 +3,7 @@ import unittest
 from sss.zero_system import MindfulEmbodimentSkill
 
 
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-  class TestMindfulEmbodimentSkill(unittest.TestCase):
-  =======
-  class TestMindfulEmbodiment(unittest.TestCase):
-  >>>>>>> main
+class TestMindfulEmbodiment(unittest.TestCase):
     def setUp(self):
         self.skill = MindfulEmbodimentSkill()
 
@@ -33,9 +29,3 @@ from sss.zero_system import MindfulEmbodimentSkill
         self.assertEqual(result["mood"], "caring")
         self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
 
-
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-  if __name__ == "__main__":
-      unittest.main()
-  =======
-  >>>>>>> main

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,10 +1,6 @@
-import logging
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-
-  from sss.zero_system import is_sibling_request, ZeroSystem
-  =======
-  >>>>>>> main
-
+import io
+import contextlib
+import unittest
 
 from sss.zero_system import is_sibling_request, ZeroSystem
 
@@ -13,10 +9,8 @@ class TestRequest(unittest.TestCase):
     def test_is_sibling_request_true(self):
         self.assertTrue(is_sibling_request("اريد اخ صغير يساعدني"))
 
-
     def test_is_sibling_request_false(self):
         self.assertFalse(is_sibling_request("اريد صديق جديد"))
-
 
     def test_interact_logs_and_output(self):
         system = ZeroSystem()
@@ -34,6 +28,3 @@ class TestRequest(unittest.TestCase):
         self.assertIn(f"User message: {message}", log_text)
         self.assertTrue(any("AI response:" in record for record in log.output))
 
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_zero_system.py
+++ b/tests/test_zero_system.py
@@ -1,89 +1,14 @@
-  <<<<<<< codex/add-instructions-for-running-cli.py-and-pytest
-    import os
-  import sys
-  import pytest
+import unittest
 
-  sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-  from zero_system import ZeroSystem, is_sibling_request
+from sss.zero_system import ZeroSystem
 
 
-  def test_is_sibling_request_detects_true():
-      assert is_sibling_request("اريد اخ صغير يساعدني")
+class TestZeroSystem(unittest.TestCase):
+    def test_create_sibling_increments_count(self):
+        system = ZeroSystem()
+        genesis_skill = system.skills["sibling_genesis"]
+        before = genesis_skill.siblings_created
+        system.create_sibling()
+        after = genesis_skill.siblings_created
+        self.assertEqual(after, before + 1)
 
-
-  def test_is_sibling_request_detects_false():
-      assert not is_sibling_request("مرحبا كيف الحال")
-
-
-  def test_zero_system_status_contains_fields():
-      system = ZeroSystem()
-      status = system.system_status()
-      assert "uptime" in status
-      assert "interactions" in status
-      assert "skills" in status
-      assert "dna_backup" in status
-
-
-  def test_create_sibling_increments_count():
-      system = ZeroSystem()
-      first = system.create_sibling()
-      second = system.create_sibling()
-      assert first["sibling_id"] != second["sibling_id"]
-  =======
-    <<<<<<< codex/add-tests-for-is_sibling_request-and-zerosystem.interact
-    import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-    import logging
-
-    import pytest
-
-    import zero_system
-
-
-    def test_is_sibling_request_true_cases():
-        assert zero_system.is_sibling_request("أريد أخاً صغيراً يساعدني")
-        assert zero_system.is_sibling_request("اريد شقيق اصغر للمساعدة")
-
-
-    def test_is_sibling_request_false_cases():
-        assert not zero_system.is_sibling_request("اريد اخ كبير")
-        assert not zero_system.is_sibling_request("مرحبا كيف الحال؟")
-
-
-    def test_zero_system_interact_sibling(capsys, caplog):
-        caplog.set_level(logging.INFO)
-        system = zero_system.ZeroSystem()
-        response = system.interact("أريد أخاً صغيراً")
-        out = capsys.readouterr().out
-        assert "المستخدم: أريد أخاً صغيراً" in out
-        assert "تم إنشاء أخ رقمي #1" in out
-        assert response["sibling_id"] == "أخ رقمي #1"
-        assert "Triggering sibling_genesis skill" in caplog.text
-        assert system.interaction_count == 1
-
-
-    def test_zero_system_interact_default(capsys, caplog):
-        caplog.set_level(logging.INFO)
-        system = zero_system.ZeroSystem()
-        response = system.interact("مرحبا")
-        out = capsys.readouterr().out
-        assert "المستخدم: مرحبا" in out
-        assert "أخوك الذكي" in response["output"]
-        assert "AI response" in caplog.text
-        assert system.interaction_count == 1
-    =======
-    import unittest
-
-    from sss.zero_system import ZeroSystem
-
-    class TestZeroSystem(unittest.TestCase):
-        def test_create_sibling_increments_count(self):
-            system = ZeroSystem()
-            genesis_skill = system.skills["sibling_genesis"]
-            before = genesis_skill.siblings_created
-            system.create_sibling()
-            after = genesis_skill.siblings_created
-            self.assertEqual(after, before + 1)
-
-    >>>>>>> main
-  >>>>>>> main

--- a/zero_system.py
+++ b/zero_system.py
@@ -6,13 +6,9 @@
 import json
 import hashlib
 from datetime import datetime
-  from abc import ABC, abstractmethod
-  <<<<<<< codex/create-logger.py-with-zerosystemlogger-class
-  from logger import ZeroSystemLogger
-  =======
-  import logging
-  import os
-  >>>>>>> main
+from abc import ABC, abstractmethod
+import logging
+import os
 
 
 def normalize_arabic(text: str) -> str:
@@ -178,9 +174,8 @@ class SiblingAIGenesisSkill(AbstractSkill):
 
 # ======================= نواة الأخ الرقمي =======================
 class AmrikyyBrotherAI:
-    def __init__(self, skills, logger=None):
+    def __init__(self, skills):
         self.skills = skills
-        self.logger = logger or ZeroSystemLogger()
         self.memory = []
         self.personality = {
             "name": "أخوك الذكي",
@@ -198,54 +193,24 @@ class AmrikyyBrotherAI:
         })
 
         # تفعيل المهارات حسب المحتوى
-        skill_used = None
-        result = None
-          if is_sibling_request(message):
-  <<<<<<< codex/create-logger.py-with-zerosystemlogger-class
-              skill_used = "sibling_genesis"
-              result = self.skills[skill_used].execute()
-          elif "صوت" in message:
-              skill_used = "mindful_embodiment"
-              result = self.skills[skill_used].execute(message)
-          elif user_profile:
-              skill_used = "true_friendship"
-              result = self.skills[skill_used].execute(user_profile, message)
-          else:
-              result = {
-                  "status": "success",
-                  "output": "مرحباً! أنا أخوك الذكي، جاهز لمساعدتك في أي شيء \U0001F680",
-                  "personality": self.personality,
-              }
+        if is_sibling_request(message):
+            logging.info("Triggering sibling_genesis skill")
+            return self.skills["sibling_genesis"].execute()
+        if "صوت" in message:
+            logging.info("Triggering mindful_embodiment skill")
+            return self.skills["mindful_embodiment"].execute(message)
+        if user_profile:
+            logging.info("Triggering true_friendship skill")
+            return self.skills["true_friendship"].execute(user_profile, message)
 
-          voice_style = result.get("voice_style", self.personality.get("voice"))
-          self.logger.log_event(
-              message,
-              skill=skill_used or "default",
-              mood=self.personality.get("mood"),
-              voice_style=voice_style,
-              response=result.get("output"),
-          )
-
-          return result
-  =======
-              logging.info("Triggering sibling_genesis skill")
-              return self.skills["sibling_genesis"].execute()
-          if "صوت" in message:
-              logging.info("Triggering mindful_embodiment skill")
-              return self.skills["mindful_embodiment"].execute(message)
-          if user_profile:
-              logging.info("Triggering true_friendship skill")
-              return self.skills["true_friendship"].execute(user_profile, message)
-
-          # الرد الافتراضي
-          response = {
-              "status": "success",
-              "output": "مرحباً! أنا أخوك الذكي، جاهز لمساعدتك في أي شيء \U0001F680",
-              "personality": self.personality
-          }
-          logging.info("Default response: %s", response["output"])
-          return response
-  >>>>>>> main
+        # الرد الافتراضي
+        response = {
+            "status": "success",
+            "output": "مرحباً! أنا أخوك الذكي، جاهز لمساعدتك في أي شيء \U0001F680",
+            "personality": self.personality
+        }
+        logging.info("Default response: %s", response["output"])
+        return response
 
     def grow(self, new_skill):
         """يطور مهارة جديدة"""
@@ -293,11 +258,8 @@ class ZeroSystem:
         # إنشاء الحمض النووي
         self.dna = DigitalDNA()
 
-        # مسجل الأحداث
-        self.logger = ZeroSystemLogger()
-
         # تهيئة الأخ الرقمي
-        self.brother_ai = AmrikyyBrotherAI(self.skills, self.logger)
+        self.brother_ai = AmrikyyBrotherAI(self.skills)
 
         # إحصائيات النظام
         self.start_time = datetime.now()


### PR DESCRIPTION
## Summary
- remove extraneous `logging` import from `tests/test_request.py`
- restore clean versions of unittest-based tests
- add `sys.path` adjustment for tests
- revert `zero_system` to a stable version with configurable log path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68487f5222c88330bed6df3e6b29ebc7