### PR TITLE
Ensure pytest imports modules without PYTHONPATH

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os, sys
+ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
+if ROOT_DIR not in sys.path:
+    sys.path.insert(0, ROOT_DIR)


### PR DESCRIPTION
## Summary
- update `tests/__init__.py` so tests add the repo root to `sys.path`

## Testing
- `pytest -q` *(fails: IndentationError in project files)*

------
https://chatgpt.com/codex/tasks/task_e_684880bfe6388330b07daead54b4a4c1