### PR TITLE
Fix logging configuration placement

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,11 +20,6 @@ def run_interactive(system: ZeroSystem) -> None:
 
 
 def main(argv: list[str] | None = None) -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        filename="zero_system.log",
-        format="%(asctime)s - %(levelname)s - %(message)s",
-    )
 
     parser = argparse.ArgumentParser(description="Zero System command line interface")
     parser.add_argument("--log", default="zero_system.log", help="path to log file")

--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -1,98 +1,20 @@
-  <<<<<<< main
-    <<<<<<< codex/rewrite-tests-to-use-unittest
-    import unittest
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import unittest
 
-    from sss.zero_system import ZeroSystem
-
-
-    class TestDynamicSkill(unittest.TestCase):
-        def test_dynamic_skill_registration(self):
-            system = ZeroSystem()
-            message = system.brother_ai.grow("test_skill")
-            self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-            self.assertIn("test_skill", system.brother_ai.skills)
-            self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-            self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
+from sss.zero_system import ZeroSystem
 
 
-    if __name__ == "__main__":
-        unittest.main()
-    =======
-      <<<<<<< codex/add-logging-to-zerosystem.interact
-      import unittest
-
-      <<<<<<< codex/update-.gitignore-and-remove-log-files
-              self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-              self.assertIn("test_skill", system.brother_ai.skills)
-              self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-              self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-      =======
-          from sss.zero_system import ZeroSystem
+class TestDynamicSkill(unittest.TestCase):
+    def test_dynamic_skill_registration(self):
+        system = ZeroSystem()
+        message = system.brother_ai.grow("test_skill")
+        self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
+        self.assertIn("test_skill", system.brother_ai.skills)
+        self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
+        self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
 
 
-        class TestDynamicSkill(unittest.TestCase):
-            def test_dynamic_skill_registration(self):
-                system = ZeroSystem()
-                message = system.brother_ai.grow("test_skill")
-                self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-                self.assertIn("test_skill", system.brother_ai.skills)
-                self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-                self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-      >>>>>>> main
+if __name__ == "__main__":
+    unittest.main()
 
-
-      if __name__ == "__main__":
-          unittest.main()
-      =======
-      import os, sys
-
-      sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-      import unittest
-
-        <<<<<<< codex/standardize-imports-in-tests-directory
-        =======
-        from zero_system import ZeroSystem
-
-        >>>>>>> main
-
-      class TestDynamicSkill(unittest.TestCase):
-          def test_dynamic_skill_registration(self):
-                system = ZeroSystem()
-                message = system.brother_ai.grow("test_skill")
-                self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-                self.assertIn("test_skill", system.brother_ai.skills)
-                self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-                self.assertEqual(
-        <<<<<<< codex/standardize-imports-in-tests-directory
-                    system.brother_ai.skills["test_skill"](),
-                    {"status": "under_development"},
-                )
-        =======
-                    system.brother_ai.skills["test_skill"](), {"status": "under_development"}
-                )
-
-
-        if __name__ == "__main__":
-            unittest.main()
-        >>>>>>> main
-      >>>>>>> main
-    >>>>>>> main
-  =======
-  import unittest
-
-  from sss.zero_system import ZeroSystem
-
-
-  class TestDynamicSkill(unittest.TestCase):
-      def test_dynamic_skill_registration(self):
-          system = ZeroSystem()
-          message = system.brother_ai.grow("test_skill")
-          self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-          self.assertIn("test_skill", system.brother_ai.skills)
-          self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-          self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-
-
-  if __name__ == "__main__":
-      unittest.main()
-  >>>>>>> codex/debug-pull-issue

--- a/tests/test_mindful_embodiment.py
+++ b/tests/test_mindful_embodiment.py
@@ -1,103 +1,37 @@
-  <<<<<<< main
-    <<<<<<< codex/rewrite-tests-to-use-unittest
-    import unittest
+import os, sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import unittest
 
-    from sss.zero_system import MindfulEmbodimentSkill
-    =======
-      <<<<<<< codex/add-logging-to-zerosystem.interact
-      import unittest
-
-     codex/update-.gitignore-and-remove-log-files
-    class TestMindfulEmbodiment(unittest.TestCase):
-
-      from sss.zero_system import MindfulEmbodimentSkill
-
-      import os, sys
-
-      sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-      import unittest
-
-      from zero_system import MindfulEmbodimentSkill
-      >>>>>>> main
-    >>>>>>> main
+from sss.zero_system import MindfulEmbodimentSkill
 
 
-    class TestMindfulEmbodimentSkill(unittest.TestCase):
-        def setUp(self):
-            self.skill = MindfulEmbodimentSkill()
-    <<<<<<< codex/rewrite-tests-to-use-unittest
-    =======
-     main
-    >>>>>>> main
-  =======
-  import unittest
+class TestMindfulEmbodimentSkill(unittest.TestCase):
+    def setUp(self):
+        self.skill = MindfulEmbodimentSkill()
 
-  from sss.zero_system import MindfulEmbodimentSkill
+    def test_default_context(self):
+        result = self.skill.execute("اهلا")
+        self.assertEqual(result["mood"], "default")
+        self.assertEqual(result["voice_style"], "صوت هادئ وواضح")
+        self.assertIn("مرحباً بك", result["output"])
 
+    def test_tech_context(self):
+        result = self.skill.execute("لدي سؤال تقني حول البرمجة")
+        self.assertEqual(result["mood"], "professional")
+        self.assertEqual(result["voice_style"], "صوت رسمي وتحليلي")
+        self.assertIn("استفساراتك التقنية", result["output"])
 
-  class TestMindfulEmbodiment(unittest.TestCase):
-      def setUp(self):
-          self.skill = MindfulEmbodimentSkill()
-  >>>>>>> codex/debug-pull-issue
+    def test_fun_context(self):
+        result = self.skill.execute("لنمرح ونضحك سويا")
+        self.assertEqual(result["mood"], "cheerful")
+        self.assertEqual(result["voice_style"], "صوت سعيد ومتفائل")
 
-        def test_default_context(self):
-            result = self.skill.execute("اهلا")
-            self.assertEqual(result["mood"], "default")
-            self.assertEqual(result["voice_style"], "صوت هادئ وواضح")
-            self.assertIn("مرحباً بك", result["output"])
-
-        def test_tech_context(self):
-            result = self.skill.execute("لدي سؤال تقني حول البرمجة")
-            self.assertEqual(result["mood"], "professional")
-            self.assertEqual(result["voice_style"], "صوت رسمي وتحليلي")
-            self.assertIn("استفساراتك التقنية", result["output"])
-
-      def test_fun_context(self):
-          result = self.skill.execute("لنمرح ونضحك سويا")
-          self.assertEqual(result["mood"], "cheerful")
-          self.assertEqual(result["voice_style"], "صوت سعيد ومتفائل")
-
-  <<<<<<< main
-    <<<<<<< codex/rewrite-tests-to-use-unittest
-        def test_support_context(self):
-            result = self.skill.execute("انا احتاج دعم عاجل")
-            self.assertEqual(result["mood"], "caring")
-            self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
+    def test_support_context(self):
+        result = self.skill.execute("انا احتاج دعم عاجل")
+        self.assertEqual(result["mood"], "caring")
+        self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
 
 
-    if __name__ == "__main__":
-        unittest.main()
-    =======
-      <<<<<<< codex/add-logging-to-zerosystem.interact
-          def test_support_context(self):
-              result = self.skill.execute("انا احتاج دعم عاجل")
-              self.assertEqual(result["mood"], "caring")
-              self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
+if __name__ == "__main__":
+    unittest.main()
 
-
-      if __name__ == "__main__":
-          unittest.main()
-      =======
-            def test_support_context(self):
-                result = self.skill.execute("انا احتاج دعم عاجل")
-                self.assertEqual(result["mood"], "caring")
-                self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
-         codex/standardize-imports-in-tests-directory
-
-
-
-        if __name__ == "__main__":
-            unittest.main()
-         main
-      >>>>>>> main
-    >>>>>>> main
-  =======
-      def test_support_context(self):
-          result = self.skill.execute("انا احتاج دعم عاجل")
-          self.assertEqual(result["mood"], "caring")
-          self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
-
-
-  if __name__ == "__main__":
-      unittest.main()
-  >>>>>>> codex/debug-pull-issue

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,184 +1,33 @@
-  <<<<<<< main
-    <<<<<<< codex/rewrite-tests-to-use-unittest
-    import logging
+import os, sys, io, contextlib
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+import unittest
 
-    from sss.zero_system import is_sibling_request, ZeroSystem
-    =======
-      <<<<<<< codex/update-.gitignore-and-remove-log-files
-      import io
-      import contextlib
-      import unittest
-    >>>>>>> main
-
-          from sss.zero_system import is_sibling_request, ZeroSystem
-      =======
-        <<<<<<< codex/standardize-imports-in-tests-directory
-        import logging
-        import io
-        import contextlib
-        import unittest
-      =======
-        <<<<<<< codex/resolve-merge-conflicts-in-files
-        import io
-        import logging
-        import contextlib
-        import unittest
-    >>>>>>> main
-        =======
-        <<
-          sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-          import io
-          import contextlib
-          import logging
-          import unittest
-          =======
-            import logging
-            <<<<<<< codex/update-import-for-zero_system-module
-            import pytest
-            from zero_system import is_sibling_request, ZeroSystem
-            =======
-              <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-
-              from sss.zero_system import is_sibling_request, ZeroSystem
-              =======
-              >>>>>>> main
-          >>>>>>> main
-        <<<<< codex/remove-merge-markers-and-refactor-logging-setup
-        import os, sys
+from sss.zero_system import is_sibling_request, ZeroSystem
 
 
-        from sss.zero_system import is_sibling_request, ZeroSystem
-        >>>>>>> main
+class TestRequest(unittest.TestCase):
+    def test_is_sibling_request_true(self):
+        self.assertTrue(is_sibling_request("اريد اخ صغير يساعدني"))
 
-      >>>>>>> main
+    def test_is_sibling_request_false(self):
+        self.assertFalse(is_sibling_request("اريد صديق جديد"))
 
-      class TestRequest(unittest.TestCase):
-          def test_is_sibling_request_true(self):
-              self.assertTrue(is_sibling_request("اريد اخ صغير يساعدني"))
-    >>>>>>> main
-
-      <<<<<<< codex/remove-merge-markers-and-refactor-logging-setup
-          def test_is_sibling_request_false(self):
-              self.assertFalse(is_sibling_request("اريد صديق جديد"))
-
-      <<<<<<< codex/resolve-merge-conflicts-in-files
-      class TestRequest(unittest.TestCase):
-          def test_is_sibling_request_true(self):
-              self.assertTrue(is_sibling_request("اريد اخ صغير يساعدني"))
-
-          def test_is_sibling_request_false(self):
-              self.assertFalse(is_sibling_request("اريد صديق جديد"))
-
-    <<<<<<< codex/standardize-imports-in-tests-directory
-        def test_is_sibling_request_false(self):
-            self.assertFalse(is_sibling_request("اريد صديق جديد"))
-
-        def test_interact_logs_and_output(self):
-            system = ZeroSystem()
-            message = "مرحبا"
-            user = {"id": "u", "name": "Test"}
-            buf = io.StringIO()
-            with self.assertLogs(level="INFO") as log, contextlib.redirect_stdout(buf):
-                response = system.interact(message, user)
-            captured = buf.getvalue()
-            self.assertIn(f"\U0001F464 المستخدم: {message}", captured)
-            self.assertIn("\U0001F916 الذكاء:", captured)
-            self.assertEqual(response["status"], "success")
-            log_text = "\n".join(log.output)
-            self.assertIn(f"User message: {message}", log_text)
-            self.assertTrue(any("AI response:" in record for record in log.output))
-    =======
-          def test_interact_logs_and_output(self):
-              system = ZeroSystem()
-              message = "مرحبا"
-              user = {"id": "u", "name": "Test"}
-              buf = io.StringIO()
-              with self.assertLogs(level="INFO") as log, \
-                   contextlib.redirect_stdout(buf):
-                  response = system.interact(message, user)
-              captured = buf.getvalue()
-              self.assertIn(f"\U0001F464 المستخدم: {message}", captured)
-              self.assertIn("\U0001F916 الذكاء:", captured)
-              self.assertEqual(response["status"], "success")
-              log_text = "\n".join(log.output)
-              self.assertIn(f"User message: {message}", log_text)
-              self.assertTrue(any("AI response:" in record for record in log.output))
-      =======
-            def test_interact_logs_and_output(self):
-                system = ZeroSystem()
-                message = "مرحبا"
-                user = {"id": "u", "name": "Test"}
-                buf = io.StringIO()
-                with self.assertLogs(level="INFO") as log, contextlib.redirect_stdout(buf):
-                    response = system.interact(message, user)
-                captured = buf.getvalue()
-                self.assertIn(f"\U0001f464 المستخدم: {message}", captured)
-                self.assertIn("\U0001f916 الذكاء:", captured)
-                self.assertEqual(response["status"], "success")
-                log_text = "\n".join(log.output)
-                self.assertIn(f"User message: {message}", log_text)
-                self.assertTrue(any("AI response" in record for record in log.output))
-        =======
-
-              def test_is_sibling_request_false(self):
-                  self.assertFalse(is_sibling_request("اريد صديق جديد"))
+    def test_interact_logs_and_output(self):
+        system = ZeroSystem()
+        message = "مرحبا"
+        user = {"id": "u", "name": "Test"}
+        buf = io.StringIO()
+        with self.assertLogs(level="INFO") as log, contextlib.redirect_stdout(buf):
+            response = system.interact(message, user)
+        captured = buf.getvalue()
+        self.assertIn(f"\U0001F464 المستخدم: {message}", captured)
+        self.assertIn("\U0001F916 الذكاء:", captured)
+        self.assertEqual(response["status"], "success")
+        log_text = "\n".join(log.output)
+        self.assertIn(f"User message: {message}", log_text)
+        self.assertTrue(any("AI response" in record for record in log.output))
 
 
-              def test_interact_logs_and_output(self):
-                  system = ZeroSystem()
-                  message = "مرحبا"
-                  user = {"id": "u", "name": "Test"}
-                  buf = io.StringIO()
-                  with self.assertLogs(level="INFO") as log, \
-                       contextlib.redirect_stdout(buf):
-                      response = system.interact(message, user)
-                  captured = buf.getvalue()
-                  self.assertIn(f"\U0001F464 المستخدم: {message}", captured)
-                  self.assertIn("\U0001F916 الذكاء:", captured)
-                  self.assertEqual(response["status"], "success")
-                  log_text = "\n".join(log.output)
-                  self.assertIn(f"User message: {message}", log_text)
-                  self.assertTrue(any("AI response:" in record for record in log.output))
-        >>>>>>> main
-      >>>>>>> main
+if __name__ == "__main__":
+    unittest.main()
 
-
-      if __name__ == "__main__":
-          unittest.main()
-    >>>>>>> main
-  =======
-  import logging
-  import unittest
-  import io
-  import contextlib
-
-  from sss.zero_system import is_sibling_request, ZeroSystem
-
-
-  class TestRequest(unittest.TestCase):
-      def test_is_sibling_request_true(self):
-          self.assertTrue(is_sibling_request("اريد اخ صغير يساعدني"))
-
-      def test_is_sibling_request_false(self):
-          self.assertFalse(is_sibling_request("اريد صديق جديد"))
-
-      def test_interact_logs_and_output(self):
-          system = ZeroSystem()
-          message = "مرحبا"
-          user = {"id": "u", "name": "Test"}
-          buf = io.StringIO()
-          with self.assertLogs(level="INFO") as log, \
-               contextlib.redirect_stdout(buf):
-              response = system.interact(message, user)
-          captured = buf.getvalue()
-          self.assertIn(f"\U0001F464 المستخدم: {message}", captured)
-          self.assertIn("\U0001F916 الذكاء:", captured)
-          self.assertEqual(response["status"], "success")
-          log_text = "\n".join(log.output)
-          self.assertIn(f"User message: {message}", log_text)
-          self.assertTrue(any("AI response:" in record for record in log.output))
-
-
-  if __name__ == "__main__":
-      unittest.main()
-  >>>>>>> codex/debug-pull-issue


### PR DESCRIPTION
## Summary
- ensure `logging.basicConfig` only runs after CLI argument parsing
- clean up unit tests with merge markers removed

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849703efec48330af970ff1cf5f1483