### PR TITLE
Fix merge conflicts in tests

### DIFF
--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -2,18 +2,6 @@ import unittest
 
 from sss.zero_system import ZeroSystem
 
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-  =======
-
-  class TestDynamicSkill(unittest.TestCase):
-      def test_dynamic_skill_registration(self):
-          system = ZeroSystem()
-          message = system.brother_ai.grow("test_skill")
-          self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-          self.assertIn("test_skill", system.brother_ai.skills)
-          self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-          self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-  >>>>>>> main
 
 class TestDynamicSkill(unittest.TestCase):
     def test_dynamic_skill_registration(self):
@@ -23,10 +11,3 @@ class TestDynamicSkill(unittest.TestCase):
         self.assertIn("test_skill", system.brother_ai.skills)
         self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
         self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-
-  if __name__ == "__main__":
-      unittest.main()
-  =======
-  >>>>>>> main

--- a/tests/test_mindful_embodiment.py
+++ b/tests/test_mindful_embodiment.py
@@ -3,11 +3,7 @@ import unittest
 from sss.zero_system import MindfulEmbodimentSkill
 
 
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-  class TestMindfulEmbodimentSkill(unittest.TestCase):
-  =======
-  class TestMindfulEmbodiment(unittest.TestCase):
-  >>>>>>> main
+class TestMindfulEmbodimentSkill(unittest.TestCase):
     def setUp(self):
         self.skill = MindfulEmbodimentSkill()
 
@@ -32,10 +28,3 @@ from sss.zero_system import MindfulEmbodimentSkill
         result = self.skill.execute("انا احتاج دعم عاجل")
         self.assertEqual(result["mood"], "caring")
         self.assertEqual(result["voice_style"], "صوت دافئ ومتعاطف")
-
-
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-  if __name__ == "__main__":
-      unittest.main()
-  =======
-  >>>>>>> main

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,10 +1,7 @@
 import logging
-  <<<<<<< fmzv63-codex/rewrite-tests-to-use-unittest
-
-  from sss.zero_system import is_sibling_request, ZeroSystem
-  =======
-  >>>>>>> main
-
+import unittest
+import io
+import contextlib
 
 from sss.zero_system import is_sibling_request, ZeroSystem
 
@@ -13,18 +10,15 @@ class TestRequest(unittest.TestCase):
     def test_is_sibling_request_true(self):
         self.assertTrue(is_sibling_request("اريد اخ صغير يساعدني"))
 
-
     def test_is_sibling_request_false(self):
         self.assertFalse(is_sibling_request("اريد صديق جديد"))
-
 
     def test_interact_logs_and_output(self):
         system = ZeroSystem()
         message = "مرحبا"
         user = {"id": "u", "name": "Test"}
         buf = io.StringIO()
-        with self.assertLogs(level="INFO") as log, \
-             contextlib.redirect_stdout(buf):
+        with self.assertLogs(level="INFO") as log, contextlib.redirect_stdout(buf):
             response = system.interact(message, user)
         captured = buf.getvalue()
         self.assertIn(f"\U0001F464 المستخدم: {message}", captured)
@@ -33,7 +27,3 @@ class TestRequest(unittest.TestCase):
         log_text = "\n".join(log.output)
         self.assertIn(f"User message: {message}", log_text)
         self.assertTrue(any("AI response:" in record for record in log.output))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/test_zero_system.py
+++ b/tests/test_zero_system.py
@@ -1,89 +1,14 @@
-  <<<<<<< codex/add-instructions-for-running-cli.py-and-pytest
-    import os
-  import sys
-  import pytest
+import unittest
 
-  sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-
-  from zero_system import ZeroSystem, is_sibling_request
+from sss.zero_system import ZeroSystem
 
 
-  def test_is_sibling_request_detects_true():
-      assert is_sibling_request("اريد اخ صغير يساعدني")
+class TestZeroSystem(unittest.TestCase):
+    def test_create_sibling_increments_count(self):
+        system = ZeroSystem()
+        genesis_skill = system.skills["sibling_genesis"]
+        before = genesis_skill.siblings_created
+        system.create_sibling()
+        after = genesis_skill.siblings_created
+        self.assertEqual(after, before + 1)
 
-
-  def test_is_sibling_request_detects_false():
-      assert not is_sibling_request("مرحبا كيف الحال")
-
-
-  def test_zero_system_status_contains_fields():
-      system = ZeroSystem()
-      status = system.system_status()
-      assert "uptime" in status
-      assert "interactions" in status
-      assert "skills" in status
-      assert "dna_backup" in status
-
-
-  def test_create_sibling_increments_count():
-      system = ZeroSystem()
-      first = system.create_sibling()
-      second = system.create_sibling()
-      assert first["sibling_id"] != second["sibling_id"]
-  =======
-    <<<<<<< codex/add-tests-for-is_sibling_request-and-zerosystem.interact
-    import sys, os; sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-    import logging
-
-    import pytest
-
-    import zero_system
-
-
-    def test_is_sibling_request_true_cases():
-        assert zero_system.is_sibling_request("أريد أخاً صغيراً يساعدني")
-        assert zero_system.is_sibling_request("اريد شقيق اصغر للمساعدة")
-
-
-    def test_is_sibling_request_false_cases():
-        assert not zero_system.is_sibling_request("اريد اخ كبير")
-        assert not zero_system.is_sibling_request("مرحبا كيف الحال؟")
-
-
-    def test_zero_system_interact_sibling(capsys, caplog):
-        caplog.set_level(logging.INFO)
-        system = zero_system.ZeroSystem()
-        response = system.interact("أريد أخاً صغيراً")
-        out = capsys.readouterr().out
-        assert "المستخدم: أريد أخاً صغيراً" in out
-        assert "تم إنشاء أخ رقمي #1" in out
-        assert response["sibling_id"] == "أخ رقمي #1"
-        assert "Triggering sibling_genesis skill" in caplog.text
-        assert system.interaction_count == 1
-
-
-    def test_zero_system_interact_default(capsys, caplog):
-        caplog.set_level(logging.INFO)
-        system = zero_system.ZeroSystem()
-        response = system.interact("مرحبا")
-        out = capsys.readouterr().out
-        assert "المستخدم: مرحبا" in out
-        assert "أخوك الذكي" in response["output"]
-        assert "AI response" in caplog.text
-        assert system.interaction_count == 1
-    =======
-    import unittest
-
-    from sss.zero_system import ZeroSystem
-
-    class TestZeroSystem(unittest.TestCase):
-        def test_create_sibling_increments_count(self):
-            system = ZeroSystem()
-            genesis_skill = system.skills["sibling_genesis"]
-            before = genesis_skill.siblings_created
-            system.create_sibling()
-            after = genesis_skill.siblings_created
-            self.assertEqual(after, before + 1)
-
-    >>>>>>> main
-  >>>>>>> main


### PR DESCRIPTION
## Summary
- remove leftover conflict markers in test files
- use a single unittest style implementation across tests
- add missing imports for tests

## Testing
- `PYTHONPATH=. pytest -q` *(fails: IndentationError in zero_system.py)*

------
https://chatgpt.com/codex/tasks/task_e_68487f28081c8330b9e9cc6193bc9856