### PR TITLE
Fix duplicate class in dynamic skill test

### DIFF
--- a/tests/test_dynamic_skill.py
+++ b/tests/test_dynamic_skill.py
@@ -1,98 +1,17 @@
-  <<<<<<< main
-    <<<<<<< codex/rewrite-tests-to-use-unittest
-    import unittest
+import unittest
 
-    from sss.zero_system import ZeroSystem
+from sss.zero_system import ZeroSystem
 
 
-    class TestDynamicSkill(unittest.TestCase):
-        def test_dynamic_skill_registration(self):
-            system = ZeroSystem()
-            message = system.brother_ai.grow("test_skill")
-            self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-            self.assertIn("test_skill", system.brother_ai.skills)
-            self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-            self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
+class TestDynamicSkill(unittest.TestCase):
+    def test_dynamic_skill_registration(self):
+        system = ZeroSystem()
+        message = system.brother_ai.grow("test_skill")
+        self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
+        self.assertIn("test_skill", system.brother_ai.skills)
+        self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
+        self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
 
 
-    if __name__ == "__main__":
-        unittest.main()
-    =======
-      <<<<<<< codex/add-logging-to-zerosystem.interact
-      import unittest
-
-      <<<<<<< codex/update-.gitignore-and-remove-log-files
-              self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-              self.assertIn("test_skill", system.brother_ai.skills)
-              self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-              self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-      =======
-          from sss.zero_system import ZeroSystem
-
-
-        class TestDynamicSkill(unittest.TestCase):
-            def test_dynamic_skill_registration(self):
-                system = ZeroSystem()
-                message = system.brother_ai.grow("test_skill")
-                self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-                self.assertIn("test_skill", system.brother_ai.skills)
-                self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-                self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-      >>>>>>> main
-
-
-      if __name__ == "__main__":
-          unittest.main()
-      =======
-      import os, sys
-
-      sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
-      import unittest
-
-        <<<<<<< codex/standardize-imports-in-tests-directory
-        =======
-        from zero_system import ZeroSystem
-
-        >>>>>>> main
-
-      class TestDynamicSkill(unittest.TestCase):
-          def test_dynamic_skill_registration(self):
-                system = ZeroSystem()
-                message = system.brother_ai.grow("test_skill")
-                self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-                self.assertIn("test_skill", system.brother_ai.skills)
-                self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-                self.assertEqual(
-        <<<<<<< codex/standardize-imports-in-tests-directory
-                    system.brother_ai.skills["test_skill"](),
-                    {"status": "under_development"},
-                )
-        =======
-                    system.brother_ai.skills["test_skill"](), {"status": "under_development"}
-                )
-
-
-        if __name__ == "__main__":
-            unittest.main()
-        >>>>>>> main
-      >>>>>>> main
-    >>>>>>> main
-  =======
-  import unittest
-
-  from sss.zero_system import ZeroSystem
-
-
-  class TestDynamicSkill(unittest.TestCase):
-      def test_dynamic_skill_registration(self):
-          system = ZeroSystem()
-          message = system.brother_ai.grow("test_skill")
-          self.assertEqual(message, "تم تطوير مهارة جديدة: test_skill")
-          self.assertIn("test_skill", system.brother_ai.skills)
-          self.assertTrue(callable(system.brother_ai.skills["test_skill"]))
-          self.assertEqual(system.brother_ai.skills["test_skill"](), {"status": "under_development"})
-
-
-  if __name__ == "__main__":
-      unittest.main()
-  >>>>>>> codex/debug-pull-issue
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- clean up merge artifacts in `tests/test_dynamic_skill.py`
- keep a single `TestDynamicSkill` class and one `__main__` block

## Testing
- `pytest tests/test_dynamic_skill.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6848d5e823fc8330a9f8255ba03f4e39