### PR TITLE
Rename branding to Zentix AI

### DIFF
--- a/templates/chat.html
+++ b/templates/chat.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Chat - Amrikyy BabyAgi</title>
+  <title>Chat - Zentix AI</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
   <script>
     async function sendMessage(e) {
@@ -33,7 +33,7 @@
 <body>
   <div class="container">
     <header class="header">
-      <h1>Amrikyy BabyAgi</h1>
+      <h1>Zentix AI</h1>
       <a href="{{ url_for('logout') }}" style="color:#39ff14;">Logout</a>
     </header>
     <main class="chat" id="chat">

--- a/templates/login.html
+++ b/templates/login.html
@@ -3,13 +3,13 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Login - Amrikyy BabyAgi</title>
+  <title>Login - Zentix AI</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 </head>
 <body>
   <div class="container">
     <header class="header">
-      <h1>Amrikyy BabyAgi</h1>
+      <h1>Zentix AI</h1>
     </header>
     <form class="input-area" action="{{ url_for('login') }}" method="post">
       <input type="text" name="username" placeholder="Username">

--- a/zero_system.py
+++ b/zero_system.py
@@ -177,7 +177,7 @@ class SiblingAIGenesisSkill(AbstractSkill):
 
 
 # ======================= نواة الأخ الرقمي =======================
-class AmrikyyBrotherAI:
+class ZentixBrotherAI:
     def __init__(self, skills, logger=None):
         self.skills = skills
         self.logger = logger or ZeroSystemLogger()
@@ -297,7 +297,7 @@ class ZeroSystem:
         self.logger = ZeroSystemLogger()
 
         # تهيئة الأخ الرقمي
-        self.brother_ai = AmrikyyBrotherAI(self.skills, self.logger)
+        self.brother_ai = ZentixBrotherAI(self.skills, self.logger)
 
         # إحصائيات النظام
         self.start_time = datetime.now()


### PR DESCRIPTION
## Summary
- update login and chat templates to say *Zentix AI*
- rename `AmrikyyBrotherAI` class to `ZentixBrotherAI`
- rename the object creation in `ZeroSystem`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sss')*

------
https://chatgpt.com/codex/tasks/task_e_68486b343cfc8330b026f0bbcc4578c1