### PR TITLE
Fix indentation in CLI and plugin example

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -20,17 +20,7 @@ def run_interactive(system: ZeroSystem) -> None:
         pass
 
 
- codex/decide-python-version-support-and-adjust-code
 def main(argv: Optional[list[str]] = None) -> None:
-    logging.basicConfig(
-        level=logging.INFO,
-        filename="zero_system.log",
-        format="%(asctime)s - %(levelname)s - %(message)s",
-    )
-=======
-def main(argv: list[str] | None = None) -> None:
- main
-
     parser = argparse.ArgumentParser(description="Zero System command line interface")
     parser.add_argument("--log", default="zero_system.log", help="path to log file")
     sub = parser.add_subparsers(dest="command", required=True)

--- a/plugin_example.py
+++ b/plugin_example.py
@@ -22,9 +22,6 @@ class PluginRegistry:
         return cls._plugins.get(name)
 
 
-import math
-
-
 class CalculatorPlugin(Plugin):
     """Simple plugin that adds two numbers with basic validation."""
 
@@ -37,7 +34,6 @@ class CalculatorPlugin(Plugin):
         if a is None or b is None:
             raise ValueError("CalculatorPlugin requires 'a' and 'b'.")
 
- codex/update-input-validation-in-calculatorplugin.execute
         numeric_types = (int, float, Decimal)
         if not isinstance(a, numeric_types) or not isinstance(b, numeric_types):
             raise TypeError("CalculatorPlugin inputs must be numeric.")
@@ -62,19 +58,6 @@ class CalculatorPlugin(Plugin):
             b = Decimal(str(b))
 
         return {"result": a + b}
-=======
-        if not isinstance(a, (int, float)) or not isinstance(b, (int, float)):
-            raise TypeError("Inputs must be numeric.")
-
-        result = a + b
-
-        if isinstance(result, float) and math.isinf(result):
-            raise OverflowError("Result is infinite")
-        if isinstance(result, float) and math.isnan(result):
-            raise ValueError("Result is NaN")
-
-        return {"result": result}
- main
 
 
 class Agent:


### PR DESCRIPTION
## Summary
- remove leftover conflict markers
- normalize indentation and top-level spacing in `cli.py`
- normalize indentation and spacing in `plugin_example.py`

## Testing
- `pytest -q` *(fails: Expected '=' after a key in a key/value pair)*

------
https://chatgpt.com/codex/tasks/task_e_68498154be7083309fd4674a4c9c025b